### PR TITLE
fix(mobile): header iOS safe-area + icône pokeball

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,8 +4,16 @@ const config: CapacitorConfig = {
   appId: 'ch.divcom.pokedex',
   appName: 'Pokédex',
   webDir: 'dist',
+  // Couleur d'arrière-plan de la WebView (visible derrière le contenu
+  // pendant le chargement et dans la zone du notch iOS).
+  // Doit matcher le fond du thème dark Vuetify pour éviter le flash blanc.
+  backgroundColor: '#121212',
   ios: {
-    contentInset: 'always',
+    // 'never' : la WebView s'étend SOUS la status bar (le notch).
+    // C'est la WebView qui peint l'arrière-plan derrière la status bar,
+    // pas iOS — ainsi le thème sombre Vuetify est visible jusqu'en haut.
+    // Le padding du header est géré par .app-bar-safe (env(safe-area-inset-top)).
+    contentInset: 'never',
   },
   android: {
     allowMixedContent: false,

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -3,7 +3,12 @@
   Barre d'application plate
     * flat supprime l'ombre sous la barre
   -->
-  <v-app-bar flat>
+  <!--
+  v-app-bar avec respect des safe areas iOS (notch / Dynamic Island).
+  La classe .app-bar-safe ajoute le padding-top env(safe-area-inset-top)
+  pour que le contenu ne passe pas sous la barre de statut système.
+  -->
+  <v-app-bar class="app-bar-safe" flat>
     <!--
     Conteneur de la barre d'application
       * class="d-flex align-start align-center" aligne les éléments de manière flexible, alignés en haut et centrés verticalement
@@ -17,18 +22,27 @@
         * @click redirige vers la page d'accueil
       -->
       <!--
-      Logo : taille réduite sur mobile pour libérer de l'espace au profit
-      du titre et du bouton login (cible 44pt = recommandation Apple HIG).
+      Logo : icône pokéball Material Design (native, garantie visible
+      sur fond sombre, colorisable via le thème — contrairement à un
+      PNG dont la lisibilité dépend du fond).
+      Taille adaptée mobile (cible 44pt Apple HIG) vs desktop (64).
       -->
-      <v-avatar
-        class="mr-4 pa-0 cursor-pointer"
-        image="@/assets/pokeball.svg"
-        :size="mobile ? 44 : 64"
+      <v-btn
+        class="mr-4"
+        color="red"
+        :icon="mobile ? 'mdi-pokeball' : 'mdi-pokeball'"
+        :size="mobile ? 'large' : 'x-large'"
+        variant="text"
         @click="$router.push('/')"
       />
 
-      <!-- Titre de l'application affiché dans la barre -->
-      <v-toolbar-title>Pokedex</v-toolbar-title>
+      <!--
+      Titre "Pokedex" : visible uniquement sur desktop. Sur mobile,
+      le logo pokéball à gauche fait office d'identité visuelle —
+      ça libère de la place pour le bouton login et évite la collision
+      avec le notch / Dynamic Island iOS.
+      -->
+      <v-toolbar-title v-if="!mobile">Pokedex</v-toolbar-title>
 
       <!--
       Liens de navigation générés dynamiquement
@@ -126,3 +140,26 @@ Fonction de déconnexion
     router.push('/') // Rediriger l'utilisateur vers la page d'accueil
   }
 </script>
+
+<style scoped>
+/*
+Respect des safe areas iOS sur la barre d'application.
+
+Sans ce padding, le contenu du v-app-bar passe SOUS la zone du notch
+ou de la Dynamic Island sur iPhone, ce qui cache une partie du logo
+et rend les boutons partiellement inaccessibles.
+
+env(safe-area-inset-top) :
+  - vaut ~47px sur iPhone avec Dynamic Island
+  - vaut ~44px sur iPhone avec notch (X à 14)
+  - vaut 24px sur Android (status bar)
+  - vaut 0 sur desktop et anciens téléphones sans encoche
+
+Le calc() ajuste la hauteur totale pour conserver l'espace visible
+de 64px en plus du padding nécessaire.
+*/
+.app-bar-safe {
+  padding-top: env(safe-area-inset-top, 0px);
+  height: calc(64px + env(safe-area-inset-top, 0px)) !important;
+}
+</style>

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -9,6 +9,20 @@
 //   $color-pack: false
 // );
 
+/*
+Fond sombre sur <html> et <body>.
+
+Sur Capacitor iOS, la zone du notch / Dynamic Island est dessinée par
+la WebView elle-même : sans bg explicite sur <html>, iOS affiche du
+blanc/gris clair par défaut, ce qui détonne avec le thème dark Vuetify.
+Cette règle garantit que toute zone non couverte par un composant
+(safe areas iOS, transitions de route, splash) reste sombre.
+*/
+html,
+body {
+  background-color: #121212;
+}
+
 
 /* Animation pour une puce ou bouton sélectionné */
 @keyframes selectAnimation {


### PR DESCRIPTION
Suite de la PR #26 (Capacitor). Fix le bug visuel iOS où le header passait sous le notch / Dynamic Island, et où le logo PNG était invisible sur fond sombre.

## Changements
- `v-app-bar.app-bar-safe` avec `padding-top: env(safe-area-inset-top)` et `height: calc(64px + env(safe-area-inset-top))`
- Logo PNG `v-avatar` remplacé par `v-btn icon="mdi-pokeball" color="red"` (icône MDI native, garantie visible)
- Titre "Pokedex" masqué sur mobile (le logo fait office d'identité)
- `capacitor.config.ts` : `backgroundColor: '#121212'` + `ios.contentInset: 'never'` (WebView s'étend sous status bar)
- `settings.scss` : `html, body { background-color: #121212 }` pour éviter le résidu blanc autour du notch iOS

## Testé
- iOS Simulator iPhone 15 Pro : header visible et bien décalé, pokéball rouge visible, status bar lisible
- Android emulator API 36 : header inchangé, look natif Material

🤖 Generated with [Claude Code](https://claude.com/claude-code)